### PR TITLE
Restore resource group parameter position and add unit count parameter on creation

### DIFF
--- a/src/ResourceManager/SignalR/Commands.SignalR/Cmdlets/GetAzureRmSignalR.cs
+++ b/src/ResourceManager/SignalR/Commands.SignalR/Cmdlets/GetAzureRmSignalR.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Commands.SignalR.Cmdlets
     [OutputType(typeof(PSSignalRResource))]
     public class GetAzureRmSignalR : SignalRCmdletBase, IWithResourceId
     {
-        [Parameter(
+        [Parameter(Position = 0,
             Mandatory = false,
             ParameterSetName = ListSignalRServiceParameterSet,
             HelpMessage = "The resource group name.")]

--- a/src/ResourceManager/SignalR/Commands.SignalR/Cmdlets/GetAzureRmSignalRKey.cs
+++ b/src/ResourceManager/SignalR/Commands.SignalR/Cmdlets/GetAzureRmSignalRKey.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Commands.SignalR.Cmdlets
     [OutputType(typeof(PSSignalRKeys))]
     public class GetAzureRmSignalRKey : SignalRCmdletBase, IWithInputObject, IWithResourceId
     {
-        [Parameter(
+        [Parameter(Position = 0,
             Mandatory = false,
             ParameterSetName = ResourceGroupParameterSet,
             HelpMessage = "The resource group name. The default one will be used if not specified.")]

--- a/src/ResourceManager/SignalR/Commands.SignalR/Cmdlets/NewAzureRmSignalRKey.cs
+++ b/src/ResourceManager/SignalR/Commands.SignalR/Cmdlets/NewAzureRmSignalRKey.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Commands.SignalR.Cmdlets
     [OutputType(typeof(bool))]
     public class NewAzureRmSignalRKey : SignalRCmdletBase, IWithInputObject, IWithResourceId
     {
-        [Parameter(
+        [Parameter(Position = 0,
             Mandatory = false,
             ParameterSetName = ResourceGroupParameterSet,
             HelpMessage = "The resource group name. The default one will be used if not specified.")]

--- a/src/ResourceManager/SignalR/Commands.SignalR/Cmdlets/RemoveAzureRmSignalR.cs
+++ b/src/ResourceManager/SignalR/Commands.SignalR/Cmdlets/RemoveAzureRmSignalR.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Commands.SignalR.Cmdlets
     [OutputType(typeof(bool))]
     public class RemoveAzureRmSignalR : SignalRCmdletBase, IWithInputObject, IWithResourceId
     {
-        [Parameter(
+        [Parameter(Position = 0,
             Mandatory = false,
             ParameterSetName = ResourceGroupParameterSet,
             HelpMessage = "The resource group name. The default one will be used if not specified.")]

--- a/src/ResourceManager/SignalR/Commands.SignalR/help/New-AzureRmSignalR.md
+++ b/src/ResourceManager/SignalR/Commands.SignalR/help/New-AzureRmSignalR.md
@@ -14,7 +14,7 @@ Create a SignalR service.
 
 ```
 New-AzureRmSignalR [[-ResourceGroupName] <String>] [-Name] <String> [[-Location] <String>] [-Sku <String>]
- [-Tag <System.Collections.Generic.IDictionary`2[System.String,System.String]>] [-AsJob]
+ [-UnitCount <Int32>] [-Tag <System.Collections.Generic.IDictionary`2[System.String,System.String]>] [-AsJob]
  [-DefaultProfile <IAzureContextContainer>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -141,6 +141,21 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UnitCount
+The SignalR service unit count, from 1 to 10. Default to 1.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 1
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
* Restore the position for the `ResourceGroupName` parameter, 
   * A lot of the other services uses `ResourceGroupName` as the first positional parameter. We would like to keep this behavior consistent with other services. The user may still use `Cmdlet-Name -Name name` if they want to provide the `Name` parameter only.
   * `Get-AzureRmSignalR` has the following use case:
      * `Get-AzureRmSignalR resource-group name`: get a specific service
      * `Get-AzureRmSignalR resource-group`: get all the services in a resource group
      * `Get-AzureRmSignalR`: get all the services in the subscription

      Remove the position for the `ResourceGroupName` will make the behavior different as normal expectation in the second form.
   * We didn't update the position of the other parameters in the current code base. Even if we decide to remove the position for `ResourceGroupName` at last, we need to update the other positions to be 0 based.
* Use the default resource group set by `Set-AzureRmDefault` when we call `New-AzureRmSignalR`, if not specified. And fallback to use the `Name` if the default is not set either.
* Remove the lowercase restriction to the `Name` parameter
* Add `UnitCount` parameter for the `New-AzureRmSignalR`, to specify the capacity in SKU. Help docs was updated accordingly.
* Add a new SKU option `Free_DS2`.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers the changes made by the pull request.

If applicable, reference the bug/issue that this pull request fixes here.
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed. You can find a more complete discussion of PowerShell cmdlet best practices [here](https://msdn.microsoft.com/en-us/library/dd878270(v=vs.85).aspx).

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md).**
- [ ] **If changes were made to any cmdlet, the XML help was regenerated using the [platyPSHelp module](https://github.com/Azure/azure-powershell/blob/preview/documentation/help-generation.md).**
- [ ] **If any large changes are made to a service, they are reflected in the respective [change log](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md#updating-the-change-log).**

### [General Guidelines](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/preview/documentation/cleaning-up-commits.md).
- [ ] The pull request does not introduce [breaking changes](https://github.com/Azure/azure-powershell/blob/preview/documentation/breaking-changes/breaking-changes-definition.md) (unless a major version change occurs in the assembly and module).

### [Testing Guidelines](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.
- [ ] PowerShell scripts used in tests should do any necessary setup as part of the test or suite setup, and should not use hard-coded values for locations or existing resources.

### [Cmdlet Signature Guidelines](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md#cmdlet-signature-guidelines)
- [ ] New cmdlets that make changes or have side effects should implement `ShouldProcess` and have `SupportShouldProcess=true` specified in the cmdlet attribute. You can find more information on `ShouldProcess` [here](https://github.com/Azure/azure-powershell/wiki/PowerShell-Cmdlet-Design-Guidelines#supportsshouldprocess).
- [ ] Cmdlet specifies `OutputType` attribute if any output is produced - if the cmdlet produces no output, it should implement a `PassThru` parameter.

### [Cmdlet Parameter Guidelines](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md#cmdlet-parameter-guidelines)
- [ ] Parameter types should not expose types from the management library - complex parameter types should be defined in the module.
- [ ] Complex parameter types are discouraged - a parameter type should be simple types as often as possible. If complex types are used, they should be shallow and easily creatable from a constructor or another cmdlet.
- [ ] Cmdlet parameter sets should be mutually exclusive - each parameter set must have at least one mandatory parameter not in other parameter sets.
